### PR TITLE
Add endpoint for download and export-data and add associated views - frontend allows Katie to download individual photos and export all data as json from admin dashboard.

### DIFF
--- a/happily_ever_uploads/gallery/urls.py
+++ b/happily_ever_uploads/gallery/urls.py
@@ -1,10 +1,12 @@
 from django.urls import path
-from .views import ImageListCreateView, ImageDeleteView, ImageDetailView
+from .views import ImageListCreateView, ImageDeleteView, ImageDetailView, ImageDownloadView, ExportDataView
 from . import views
 
 urlpatterns = [
     path('images/', ImageListCreateView.as_view(), name='image-list-create'),  
     path('images/<int:pk>/', ImageDetailView.as_view(), name='image-delete'), 
     path('images/delete/<int:pk>/', ImageDeleteView.as_view(), name='image-delete'), 
+    path('images/<int:pk>/download/', ImageDownloadView.as_view(), name='image-download'),
+    path('images/export-data/', ExportDataView.as_view(), name='export-data'),
     path('test-upload/', views.test_upload, name='test-upload'),
 ]


### PR DESCRIPTION
Hi Behnaz, I added an endpoint for /download and /export-data and added associated views. The frontend had functionality for Katie to download individual photos and export all data as json from her admin dashboard. I have not been able to test the API endpoints with the admin token via Insomnia because I haven't been able to get the local server running. It wants too much mucking around with databases and migrations which I don't think is necessary. I assume you are able to get the local server going to test the API endpoints:
GET http://your-backend-url/images/1/download/ and GET http://your-backend-url/images/export-data/ Both need admin tokens.