### PR TITLE
updated serializer, urls and views to enable admin username update

### DIFF
--- a/happily_ever_uploads/users/serializers.py
+++ b/happily_ever_uploads/users/serializers.py
@@ -25,20 +25,27 @@ class CustomUserSerializer(serializers.ModelSerializer):
             instance.set_password(validated_data.pop('password'))  # Hash password properly
             for attr, value in validated_data.items():
                 setattr(instance, attr, value)
-                instance.save()  # Explicitly save the updated instance
+                instance.save()  
                 return instance
 
-class ChangeAdminPasswordSerializer(serializers.Serializer):
-    old_password = serializers.CharField(write_only=True)
-    new_password = serializers.CharField(write_only=True)
+class ChangeAdminSerializer(serializers.Serializer):
+    current_password = serializers.CharField(write_only=True)
+    new_password = serializers.CharField(write_only=True, required=False)
+    new_username = serializers.CharField(required=False)
 
-    def validate_old_password(self, value):
+    def validate_current_password(self, value):
         user = self.context['request'].user
         if not user.check_password(value):
-            raise serializers.ValidationError("Old password is incorrect")
+            raise serializers.ValidationError("Current password is incorrect")
         return value
 
     def update(self, instance, validated_data):
-        instance.set_password(validated_data['new_password'])  # Hash new password
+        if 'new_password' in validated_data:
+            instance.set_password(validated_data['new_password'])  
+        
+        if 'new_username' in validated_data:
+            instance.username = validated_data['new_username']  
+            
+        
         instance.save()
         return instance

--- a/happily_ever_uploads/users/urls.py
+++ b/happily_ever_uploads/users/urls.py
@@ -1,9 +1,9 @@
 from django.urls import path
-from .views import LoginView, UpdateGuestUserView, ChangeAdminPasswordView
+from .views import LoginView, UpdateGuestUserView, ChangeAdminCredentialsView
 
 urlpatterns = [
     path('login/', LoginView.as_view(), name='login'),  # Single login for both admin & guest
     path('update-guest/', UpdateGuestUserView.as_view(), name='update-guest'),  # Admin updates guest credentials
-    path('change-password/', ChangeAdminPasswordView.as_view(), name='change-password'),  # Admin changes their password
+    path('change-credentials/', ChangeAdminCredentialsView.as_view(), name='change-password'),  # Admin changes their credentials
 
 ]

--- a/happily_ever_uploads/users/views.py
+++ b/happily_ever_uploads/users/views.py
@@ -5,7 +5,7 @@ from rest_framework.permissions import AllowAny, IsAdminUser
 from rest_framework.authtoken.models import Token
 from rest_framework.authtoken.views import ObtainAuthToken
 from .models import CustomUser, PasscodeGroup
-from .serializers import CustomUserSerializer, ChangeAdminPasswordSerializer
+from .serializers import CustomUserSerializer, ChangeAdminSerializer
 
 
 # Single Login Endpoint for Both Admin & Guest
@@ -81,14 +81,14 @@ class UpdateGuestUserView(APIView):
             )
 
 
-class ChangeAdminPasswordView(APIView):
+class ChangeAdminCredentialsView(APIView):
     permission_classes = [IsAdminUser]  # Ensure only admins can access
 
     def put(self, request):
-        serializer = ChangeAdminPasswordSerializer(data=request.data, context={'request': request})
+        serializer = ChangeAdminSerializer(data=request.data, context={'request': request})
 
         if serializer.is_valid():
             serializer.update(request.user, serializer.validated_data)
-            return Response({"message": "Password updated successfully"}, status=status.HTTP_200_OK)
+            return Response({"message": "Admin credentials updated successfully"}, status=status.HTTP_200_OK)
         
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Enabled admin username update 

Changes required to address on frontend: 

rename: endpoint  '/change-password/' to '/change-credentials/'

rename : 'old_password' to 'current_password'

fields on the endpoint : 

"current_password": "This field is required."
"new_username" and "new_password" is optional so the same endpoint can be used to change username and/or password

